### PR TITLE
config function was not being called

### DIFF
--- a/mkimage-alpine.sh
+++ b/mkimage-alpine.sh
@@ -85,8 +85,8 @@ mkbase
 
 
 echo -e "config\n\n"
-echo -e "$REPO\n" > $ROOTFS/etc/apk/repositories
-#conf
+#echo -e "$REPO\n" > $ROOTFS/etc/apk/repositories
+conf
 
 echo -e "pack\n\n"
 pack


### PR DESCRIPTION
This led to a -e being injected into /etc/apk/repositories and causing apk update to fail in the subsequent image.