### PR TITLE
[fix] correct how repositories urls are saved

### DIFF
--- a/mkimage-alpine.sh
+++ b/mkimage-alpine.sh
@@ -85,7 +85,7 @@ mkbase
 
 
 echo -e "config\n\n"
-echo -e "$REPO\n" > $ROOTFS/etc/apk/repositories
+echo "$REPO" > $ROOTFS/etc/apk/repositories
 #conf
 
 echo -e "pack\n\n"


### PR DESCRIPTION
When I tried to run `./mkimage-alpine.sh -r v3.7` the script saved the repo url in `/etc/apk/repositories` as:

```
-e http://nl.alpinelinux.org/alpine/v3.2/main
```
Therefore the fetch once you run a docker fails.

With my fix it works again :)